### PR TITLE
Feat 9/add result visualization streamlit

### DIFF
--- a/code/result_viz.py
+++ b/code/result_viz.py
@@ -1,14 +1,13 @@
 import os
+import argparse
 import streamlit as st
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import json
 from PIL import Image, ImageOps
-from typing import Union
 from pathlib import Path
 from deteval import calc_deteval_metrics
-import argparse
 from io import BytesIO
 
 def parse_args():
@@ -113,7 +112,10 @@ def main(opt):
 
     # 두 개의 열 생성
     col1, col2 = st.columns(2)
-    with col1:
+
+    with col2:
+        for _ in range(2):
+            st.write('\n')
         # 이미지 탐색 버튼
         search = st.columns(8)
         with search[0]:
@@ -124,18 +126,16 @@ def main(opt):
             if st.button("Next"):
                 if st.session_state.image_index < len(image_files) - 1:
                     st.session_state.image_index += 1
-
-        # Streamlit sidebar: 이미지 선택
+    with col1:
+        # 이미지 선택 sidebar
         selected_image = st.selectbox("이미지를 선택하세요:", image_files, index=st.session_state.image_index)
         if image_files.index(selected_image) != st.session_state.image_index:
             st.session_state.image_index = image_files.index(selected_image)
             st.rerun()
-
+        # unmatched box 이미지 출력
         buf, score_dict, unmatched_len = unmatched_show(opt, det_data, selected_image)
         st.image(buf, width=450)
     with col2:
-        for i in range(8):
-            st.write('\n')
         st.header('Statistics')
         st.markdown(f"##### Unmatched gt : {unmatched_len[0]}, Unmatched det : {unmatched_len[1]}")
         df = pd.DataFrame({"name": score_dict.keys(),"score": score_dict.values()}).set_index('name')

--- a/code/result_viz.sh
+++ b/code/result_viz.sh
@@ -1,0 +1,4 @@
+data_dir="/data/ephemeral/home/code/data" 
+inference_file="/data/ephemeral/home/code/predictions/output.csv" 
+
+streamlit run result_viz.py -- --data_dir "$data_dir" --inference_file "$inference_file"


### PR DESCRIPTION
## 🔴 Related Issue Number
- Resolved: #9 

## 💡 Work Description
- Deteval 결과 탐지하지 못한 gt box(파란색)와 잘못 예측된 det box(빨간색)를 시각화
- 매칭되지 못한 gt, det 박스의 개수와 precision, recall, f1score를 출력
- 실행을 위한 shell script 추가

## 📷 Screenshot
<!-- 구현한 기능을 보여주는 스크린샷을 넣어주세요. "" 안에 이미지 url을 넣어주세요. 없으면 지워주세요. -->
|기능|스크린샷|
|:--:|:--:|
|Streamlit 화면|<img src = "https://github.com/user-attachments/assets/bdc8fef2-91b8-42a6-ab9a-f906460d6c68">

## 📖 Reference
level2-objectdetection의 EDA_Streamlit.py, EDA_Streamlit.sh
https://github.com/boostcampaitech7/level2-objectdetection-cv-23/blob/main/EDA/Stramlit/EDA_Streamlit.py

## ✅ Checklists
- [x] 깃 컨벤션 및 팀 규칙에 맞게 작성되었나요?
- [x] 불필요한 코드 및 주석이나 디버깅 코드는 제거되었나요?
- [x] 기능이 동작하는지 테스트했나요?