### PR TITLE
[FEAT] add a arifacts and metric logging to wandb (feaures #25)

### DIFF
--- a/code/artifacts_download.py
+++ b/code/artifacts_download.py
@@ -1,0 +1,56 @@
+import os.path as osp
+from typing import Tuple
+import wandb
+
+def download_artifacts(
+    project: str,
+    entity: str,
+    run_id: str,
+    model_filename: str = 'epoch_30.pth'
+) -> Tuple[str, str]:
+    """
+    WandB에서 모델과 데이터셋 아티팩트 다운로드
+    
+    model_filename: 다운로드 하고 싶은 모델 파일 이름
+
+    Returns:
+        model_path: 다운로드된 모델 파일 경로
+        anno_dir: 다운로드된 데이터셋 디렉토리 경로
+    """
+    model_artifact_name=f"{entity}/{project}/model-{run_id}:latest"
+    data_artifact_name=f"{entity}/{project}/dataset_annotation:latest"
+    
+    # wandb 초기화
+    run = wandb.init(
+        project=project,
+        entity=entity,
+        id=run_id,
+        resume="must"
+    )
+    
+    try:
+        # 모델 아티팩트 다운로드
+        model_artifact = wandb.use_artifact(model_artifact_name, type='model')
+        model_dir = model_artifact.download()
+        model_path = osp.join(model_dir, model_filename)
+        
+        # 데이터셋 아티팩트 다운로드
+        data_artifact = wandb.use_artifact(data_artifact_name, type='dataset')
+        anno_dir = data_artifact.download()
+        
+        return model_path, anno_dir
+        
+    finally:
+        # wandb 종료
+        wandb.finish()
+        
+model_path, anno_dir = download_artifacts(
+    project="lv2-OCR",
+    entity="cv23-lv2-ocr",
+    run_id="bcm6tz5j", # 다운로드 하고 싶은 run_id 작성해주셔야 합니다. wandb UI에서 overview 탭에서 확인할 수 있어요. 
+    model_filename='epoch_1.pth', # 다운로드 하고 싶은 모델 파일 이름도 작성해주셔야 합니다.
+)
+
+# 다운로드된 경로 출력
+print(f"모델 경로: {model_path}")
+print(f"데이터셋 경로: {anno_dir}")

--- a/code/inference.sh
+++ b/code/inference.sh
@@ -1,8 +1,11 @@
-data_dir='/data/ephemeral/home/code/data'
-model_dir='/data/ephemeral/home/code/trained_models'
-output_dir='/data/ephemeral/home/code/outputs'
+data_dir='/data/ephemeral/home/data'
+model_dir='/data/ephemeral/home/cv-23/code/trained_models'
+output_dir='/data/ephemeral/home/cv-23/code/outputs'
 json_name='val_random' # 추론하고 싶은 json 파일의 이름을 적어주세요
 img_dir='train' # 실제 이미지가 있는 img 디렉토리 하위 폴더 (test, train 등)을 적어주세요
 
+run_id='x1il0w3g' # 추론하고 싶은 wandb run id를 적어주세요. wandb UI에서 overview 탭에서 확인할 수 있어요.
+
 python inference.py --data_dir "$data_dir" --model_dir "$model_dir" \
-                    --json_name "$json_name" --img_dir "$img_dir"
+                    --json_name "$json_name" --img_dir "$img_dir" \
+                    --run_id "$run_id"


### PR DESCRIPTION
## 🔴 Related Issue Number
- Resolved: #25 

## 💡 Work Description
- train.py에 dataset annotation 버전과 model 파일을 wandb에 artifacts로 저장
- train.py에 사전학습한 모델 파일을 불러올 수 있도록 코드 수정 
- inference.py에서 train.py를 통해 학습한 모델의 평가 지표인 DetEval과 TIoU를 wandb에서 추가 로깅할 수 있도록 함
- inference.sh에 argument : run_id 추가
- wandb에서 실행된 run의 모델 artifact 파일을 다운 받을 수 있는 artifact_download.py 작성

## 📷 Screenshot
<!-- 구현한 기능을 보여주는 스크린샷을 넣어주세요. "" 안에 이미지 url을 넣어주세요. 없으면 지워주세요. -->
|기능|스크린샷|
wandb artifacts 탭에서 train.py 실행 시 저장된 모델 파일과 데이터셋 annotation을 확인할 수 있음 (output artifacts)
<img src = "https://github.com/user-attachments/assets/4d63abd8-1a65-4b45-a871-dfd86269ef11" width ="250">
wandb UI에서 inference.sh 실행 시 계산된 DetEval 지표와 TIoU 지표를 확인할 수 있음
<img src = "https://github.com/user-attachments/assets/6fbd1a5b-ed0f-44f7-9d3a-e4e8d5a05d36" width ="250">
artifacts_download.py 실행 시 wandb 서버의 원하는 run의 artifacts를 다운로드 받을 수 있음 
<img src = "https://github.com/user-attachments/assets/44f14728-3873-4c4c-8b5d-36dc578dbb98" width ="250">


## 👥 To Reviewers
- inference.sh 실행 시 DetEval과 TIoU를 계산하고 싶은 run_id를 wandb 서버에서 해당 run의 overview에서 찾아서 작성해주셔야 합니다. run_id는 Run path(entity/project/run_id)형식에서 확인할 수 있어요. 
- artifacts_download.py 실행시에도 모델 이름을 확인해주셔야 해요. wandb 서버에서 artifacts 탭에 들어간 다음에 원하는 model artifact를 클릭하시고, files 탭 보시면 찾을 수 있어요. 

## 🚧 Uncompleted Tasks
  N/A
  
## ✅ Checklists
- [x] 깃 컨벤션 및 팀 규칙에 맞게 작성되었나요?
- [x] 불필요한 코드 및 주석이나 디버깅 코드는 제거되었나요?
- [x] 기능이 동작하는지 테스트했나요?